### PR TITLE
URL should point to textsecure-service subdomain

### DIFF
--- a/src/main/java/org/asamk/textsecure/Manager.java
+++ b/src/main/java/org/asamk/textsecure/Manager.java
@@ -53,7 +53,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 class Manager implements TextSecure {
-    private final static String URL = "https://SignalService-service.whispersystems.org";
+    private final static String URL = "https://textsecure-service.whispersystems.org";
     private final static TrustStore TRUST_STORE = new WhisperTrustStore();
 
     public final static String PROJECT_NAME = Manager.class.getPackage().getImplementationTitle();


### PR DESCRIPTION
10719a443a88d06ef5734f0e17f71316b1473edf introduced a new bug where the CLI won't connect to the Signal service, since https://SignalService-service.whipsersystems.org isn't the correct hostname. This fixes the problem by changing the URL back to what it should be.